### PR TITLE
Fix go version, rate limit and add version variabl

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.12
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -3,20 +3,32 @@
 You can get the current overview for CI signal report by running
 
 ```
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx  go run report.go
 ```
+Where the RELEASE_VERSION can be like `1.21`.
 
 It needs github token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
 
 ## Prerequisites
-- GoLang >=1.11
+- GoLang >=1.16
 
 ## Running
 ```
 git clone git@github.com:alenkacz/ci-signal-report.git <folder>
 cd <folder>
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
 ```
+
+## Ratelimits
+GitHub API has rate limits, to see how much you have used you can query like this (replace User with your GH user and Token with your Auth Token):
+```
+curl \
+  -u GIT_HUB-USER:GIT_HUB_TOKEN -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit & curl \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit
+```
+
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@
 You can get the current overview for CI signal report by running
 
 ```
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
 ```
+Where the RELEASE_VERSION can be like `1.21`.
 
 It needs github token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
 
 ## Prerequisites
-- GoLang >=1.11
+- GoLang >=1.16
 
 ## Running
 ```
 git clone git@github.com:alenkacz/ci-signal-report.git <folder>
 cd <folder>
-GITHUB_AUTH_TOKEN=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
 ```
 
 ## Example output

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 You can get the current overview for CI signal report by running
 
 ```
-GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx USER=xxx go run report.go
 ```
-Where the RELEASE_VERSION can be like `1.21`.
+Where the RELEASE_VERSION can be like `1.21` and USER is your GitHub user.
 
 It needs github token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
 
@@ -16,8 +16,17 @@ It needs github token to be able to query the project board for CI signal. For s
 ```
 git clone git@github.com:alenkacz/ci-signal-report.git <folder>
 cd <folder>
-GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx USER=xxx go run report.go
 ```
+
+## Ratelimits
+GitHub API has rate limits, to see how much you have used you can query like this (replace User with your GH user and Token with your Auth Token):
+```
+curl \
+  -u USER:TOKEN -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit
+```
+
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 You can get the current overview for CI signal report by running
 
 ```
-GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx USER=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx  go run report.go
 ```
-Where the RELEASE_VERSION can be like `1.21` and USER is your GitHub user.
+Where the RELEASE_VERSION can be like `1.21`.
 
 It needs github token to be able to query the project board for CI signal. For some reason even though those boards are available for public view, the APIs require auth. See [this documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) to set up your access token.
 
@@ -16,14 +16,16 @@ It needs github token to be able to query the project board for CI signal. For s
 ```
 git clone git@github.com:alenkacz/ci-signal-report.git <folder>
 cd <folder>
-GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx USER=xxx go run report.go
+GITHUB_AUTH_TOKEN=xxx RELEASE_VERSION=xxx go run report.go
 ```
 
 ## Ratelimits
 GitHub API has rate limits, to see how much you have used you can query like this (replace User with your GH user and Token with your Auth Token):
 ```
 curl \
-  -u USER:TOKEN -H "Accept: application/vnd.github.v3+json" \
+  -u GIT_HUB-USER:GIT_HUB_TOKEN -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/rate_limit & curl \
+  -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/rate_limit
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/alenkacz/ci-signal-report
 
-go 1.12
+go 1.16
 
 require (
-	github.com/google/go-github/v27 v27.0.4
+	github.com/google/go-github/v34 v34.0.0
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
-github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-github/v27 v27.0.4 h1:N/EEqsvJLgqTbepTiMBz+12KhwLovv6YvwpRezd+4Fg=
-github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-github/v34 v34.0.0 h1:/siYFImY8KwGc5QD1gaPf+f8QX6tLwxNIco2RkYxoFA=
+github.com/google/go-github/v34 v34.0.0/go.mod h1:w/2qlrXUfty+lbyO6tatnzIw97v1CM+/jZcwXMDiPQQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/report.go
+++ b/report.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-github/v27/github"
+	"github.com/google/go-github/v34/github"
 	"golang.org/x/oauth2"
 )
 
@@ -187,7 +187,7 @@ func getCardsFromColumn(cardsId int64, client *github.Client) ([]*issueOverview,
 			}
 			issues = append(issues, &overview)
 		}
-	}	
+	}
 	return issues, nil
 }
 
@@ -225,8 +225,8 @@ func printJobsStatistics(version string) {
 	requiredJobs := []requiredJob{
 		{OutputName: "Master-Blocking", UrlName: "sig-release-master-blocking"},
 		{OutputName: "Master-Informing", UrlName: "sig-release-master-informing"},
-		{OutputName: version+"-blocking", UrlName: "sig-release-"+version+"-blocking"},
-		{OutputName: version+"-informing", UrlName: "sig-release-"+version+"-informing"},
+		{OutputName: version + "-blocking", UrlName: "sig-release-" + version + "-blocking"},
+		{OutputName: version + "-informing", UrlName: "sig-release-" + version + "-informing"},
 	}
 
 	result := make([]statistics, 0)


### PR DESCRIPTION
Hi @alenkacz 

I'm the CI Signal Lead for 1.22 and I want to give this little tool a rebirth as I think we need to communicate more actively the signals.
This PR does:
- integrate GitHub Token into the http.Get so you don't run into rate limits of GH
- upgrade GO version
- add ENV for release Version

Out of interest, do you want to keep this maintained in your repo? I saw last commit is some time ago.

